### PR TITLE
Resolve bugs, readability issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 billy, jake
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# 30sep2016
+#
+
+CC=gcc
+CFLAGS=-Wall -DINTELHEX_VERBOSE -DVERBOSE
+CFLAGDBG= -DDEBUG
+SOURCES=main.c intelhex/intelhex.c
+HEADERS=intelhex/intelhex.h
+BIN=rx63nprog
+
+SILENT=1> /dev/null
+TEMP=/dev/null
+
+default build: $(BIN)
+	
+$(BIN): $(SOURCES) $(HEADERS)
+	$(CC) $(CFLAGS) -o $(BIN) $(SOURCES)
+
+debug:	CFLAGS+= $(CFLAGDBG)	
+debug:	build
+
+clean:
+	rm -f $(BIN)


### PR DESCRIPTION
1.  Remove bool return values
    - for return value consistency
2.  Add logging defines
    - increase understandability for users and developers
    - integrated in Makefile
3.  Add Makefile:
    - `make`
    - `make debug`
4.  Placed all defines and global declarations at the top
    - increase readability
5.  Added/modified COMMAND and RESPONSE enums
    - increase readability
6.  All globals are renamed with g_*** prefix
    - increase readability
7.  Add EXECPARAM struct for executeCommand() function
    Add support for error codes in executeCommand()
    - make readData() configurable: to control timeouts, control blocking
    - increase readability
8.  Add 30 max retries for matchBitRates()
    - removes the infinite loop
    - 30 max retries is in the specification
9.  Add cleanup for all allocated memory
    - avoid memory leaks
10. check index in setDevice(), setClockMode()
    - avoid memory access errors
11. Resolve a possible portability